### PR TITLE
Cosp.jp: add commentary and translated tags support

### DIFF
--- a/app/logical/source/extractor/cosplayer_archive.rb
+++ b/app/logical/source/extractor/cosplayer_archive.rb
@@ -60,4 +60,8 @@ class Source::Extractor::CosplayerArchive < Source::Extractor
     # Manually parse it because this site yields Shift-JIS
     HTTP::MimeType[res.mime_type].decode(res.to_s.force_encoding("shift_jis").encode("UTF-8"))
   end
+
+  def artist_commentary_desc
+    page.at("span.black_mui14150")&.text
+  end
 end

--- a/app/logical/source/extractor/cosplayer_archive.rb
+++ b/app/logical/source/extractor/cosplayer_archive.rb
@@ -64,4 +64,20 @@ class Source::Extractor::CosplayerArchive < Source::Extractor
   def artist_commentary_desc
     page.at("span.black_mui14150")&.text
   end
+
+  def tags
+    return [] unless page.present?
+
+    page.search("a[href^='/photo_search.aspx?']").flat_map do |a|
+      uri = URI(a[:href])
+      params = CGI.parse(uri.query)
+      params.map do |key, values|
+        next unless %w[n2 n3 n4 n5 n6 n10].include?(key)
+        [
+          a.text.strip,
+          "https://cosp.jp#{a[:href]}"
+        ]
+      end
+    end.compact
+  end
 end

--- a/test/unit/source/extractor/cosplayer_archive_test.rb
+++ b/test/unit/source/extractor/cosplayer_archive_test.rb
@@ -4,16 +4,29 @@ module Sources
   class CosplayerArchiveTest < ActiveSupport::TestCase
     context "A normal post" do
       strategy_should_work(
-        "https://www.cosp.jp/view_photo.aspx?id=13075578&m=516768",
-        image_urls: %w[https://image7.cosp.jp/images/member/g/516/516768/13075578.jpg],
-        media_files: [{ file_size: 335_524 }],
-        page_url: "https://cosp.jp/view_photo.aspx?id=13075578&m=516768",
-        profile_urls: %w[https://cosp.jp/prof.aspx?id=516768],
-        display_name: "のはね",
-        username: "cosp_516768",
-        tags: [],
+        "https://www.cosp.jp/view_photo.aspx?id=9839344&m=243519",
+        image_urls: %w[https://image7.cosp.jp/images/member/g/243/243519/9839344.jpg],
+        media_files: [{ file_size: 322_827 }],
+        page_url: "https://cosp.jp/view_photo.aspx?id=9839344&m=243519",
+        profile_urls: %w[https://cosp.jp/prof.aspx?id=243519],
+        display_name: "ぷりん",
+        username: "cosp_243519",
+        tags: [
+          [
+            "ラブライブ! School idol project",
+            "https://cosp.jp/photo_search.aspx?n2=10514"
+          ],
+          [
+            "南ことり",
+            "https://cosp.jp/photo_search.aspx?n3=59425"
+          ],
+          [
+            "Snow halation",
+            "https://cosp.jp/photo_search.aspx?n6=34577"
+          ]
+        ],
         dtext_artist_commentary_title: "",
-        dtext_artist_commentary_desc: ""
+        dtext_artist_commentary_desc: "冬といえばスノハレ〜(*´ω`*人)♪"
       )
     end
 


### PR DESCRIPTION
Fixes #3. With this, the cosplayer_archive extractor copies the description of the image into the original description field, and adds translated tags. One of the tests was changed to use a source that has a description and tags.